### PR TITLE
Fundamentals API Support

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	epBase        = "https://api.robinhood.com/"
-	epLogin       = epBase + "api-token-auth/"
-	epAccounts    = epBase + "accounts/"
-	epQuotes      = epBase + "quotes/"
-	epPortfolios  = epBase + "portfolios/"
-	epWatchlists  = epBase + "watchlists/"
-	epInstruments = epBase + "instruments/"
+	epBase         = "https://api.robinhood.com/"
+	epLogin        = epBase + "api-token-auth/"
+	epAccounts     = epBase + "accounts/"
+	epQuotes       = epBase + "quotes/"
+	epPortfolios   = epBase + "portfolios/"
+	epWatchlists   = epBase + "watchlists/"
+	epInstruments  = epBase + "instruments/"
+	epFundamentals = epBase + "fundamentals/"
 )
 
 type Client struct {

--- a/fundamentals.go
+++ b/fundamentals.go
@@ -17,6 +17,7 @@ type Fundamental struct {
 	Instrument    string  `json:"instrument"`
 }
 
+// GetFundamentals returns fundemental data for the list of stocks provided.
 func (c Client) GetFundamentals(stocks ...string) ([]Fundamental, error) {
 	url := epFundamentals + "?symbols=" + strings.Join(stocks, ",")
 	var r struct{ Results []Fundamental }

--- a/fundamentals.go
+++ b/fundamentals.go
@@ -1,0 +1,25 @@
+package robinhood
+
+import "strings"
+
+type Fundamental struct {
+  Open          float64 `json:"open,string"`
+  High          float64 `json:"high,string"`
+  Low           float64 `json:"low,string"`
+  Volume        float64 `json:"volume,string"`
+  AverageVolume float64 `json:"average_volume,string"`
+  High52Weeks   float64 `json:"high_52_weeks,string"`
+  DividendYield float64 `json:"dividend_yield,string"`
+  Low52Weeks    float64 `json:"low_52_weeks,string"`
+  MarketCap     float64 `json:"market_cap,string"`
+  PERatio       float64 `json:"pe_ratio,string"`
+  Description   string  `json:"description"`
+  Instrument    string  `json:"instrument"`
+}
+
+func (c Client) GetFundamentals(stocks ...string) ([]Fundamental, error) {
+  url := epFundamentals + "?symbols=" + strings.Join(stocks, ",")
+	var r struct{ Results []Fundamental }
+	err := c.GetAndDecode(url, &r)
+	return r.Results, err
+}

--- a/fundamentals.go
+++ b/fundamentals.go
@@ -3,22 +3,22 @@ package robinhood
 import "strings"
 
 type Fundamental struct {
-  Open          float64 `json:"open,string"`
-  High          float64 `json:"high,string"`
-  Low           float64 `json:"low,string"`
-  Volume        float64 `json:"volume,string"`
-  AverageVolume float64 `json:"average_volume,string"`
-  High52Weeks   float64 `json:"high_52_weeks,string"`
-  DividendYield float64 `json:"dividend_yield,string"`
-  Low52Weeks    float64 `json:"low_52_weeks,string"`
-  MarketCap     float64 `json:"market_cap,string"`
-  PERatio       float64 `json:"pe_ratio,string"`
-  Description   string  `json:"description"`
-  Instrument    string  `json:"instrument"`
+	Open          float64 `json:"open,string"`
+	High          float64 `json:"high,string"`
+	Low           float64 `json:"low,string"`
+	Volume        float64 `json:"volume,string"`
+	AverageVolume float64 `json:"average_volume,string"`
+	High52Weeks   float64 `json:"high_52_weeks,string"`
+	DividendYield float64 `json:"dividend_yield,string"`
+	Low52Weeks    float64 `json:"low_52_weeks,string"`
+	MarketCap     float64 `json:"market_cap,string"`
+	PERatio       float64 `json:"pe_ratio,string"`
+	Description   string  `json:"description"`
+	Instrument    string  `json:"instrument"`
 }
 
 func (c Client) GetFundamentals(stocks ...string) ([]Fundamental, error) {
-  url := epFundamentals + "?symbols=" + strings.Join(stocks, ",")
+	url := epFundamentals + "?symbols=" + strings.Join(stocks, ",")
 	var r struct{ Results []Fundamental }
 	err := c.GetAndDecode(url, &r)
 	return r.Results, err


### PR DESCRIPTION
I added support for the Fundamentals API, explained here: https://github.com/sanko/Robinhood/blob/master/Fundamentals.md

This PR adds a ```GetFundamentals``` client method and a corresponding type: ```Fundamental```.

Usage:
```go
fundamentals, err := client.GetFundamentals("AAPL", "GOOG")

for _, fundamental := range fundamentals {
  fmt.Printf("%+v\n", fundamental)
}
```