### PR TITLE
bugfix: fix "Sell" JSON marshalling

### DIFF
--- a/order.go
+++ b/order.go
@@ -21,7 +21,7 @@ func (o OrderSide) MarshalJSON() ([]byte, error) {
 //go:generate stringer -type OrderSide
 // Buy/Sell
 const (
-	Sell OrderSide = iota
+	Sell OrderSide = iota + 1
 	Buy
 )
 

--- a/orderside_string.go
+++ b/orderside_string.go
@@ -9,8 +9,9 @@ const _OrderSide_name = "SellBuy"
 var _OrderSide_index = [...]uint8{0, 4, 7}
 
 func (i OrderSide) String() string {
+	i -= 1
 	if i < 0 || i >= OrderSide(len(_OrderSide_index)-1) {
-		return "OrderSide(" + strconv.FormatInt(int64(i), 10) + ")"
+		return "OrderSide(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _OrderSide_name[_OrderSide_index[i]:_OrderSide_index[i+1]]
 }


### PR DESCRIPTION
The order type "Sell" has the integer value ```0``` and the JSON marshalling is set to ```omitempty```.
```
type apiOrder struct {
        ...
	Side          OrderSide `json:"side,omitempty"`
        ...
}
```
Therefore, if ```Side``` is set to ```robinhood.Sell```, this would be ignored by the JSON marshalling and causes this error message:

```
Error returned from API: side: ["This field is required."]
```

I increased (shifted) all integer values by 1. Can you verify this is a desired solution? If so, some of the other enums might need this as well.