### PR TITLE
Add GetCurrentpositions() for only returning non-zero positions

### DIFF
--- a/positions.go
+++ b/positions.go
@@ -18,3 +18,10 @@ func (c Client) GetPositions(a Account) ([]Position, error) {
 	err := c.GetAndDecode(a.Positions, &r)
 	return r.Results, err
 }
+
+// GetCurrentPositions returns all positions with a non-zero quantity.
+func (c Client) GetCurrentPositions(a Account) ([]Position, error) {
+	var r struct{ Results []Position }
+	err := c.GetAndDecode(a.Positions+"?nonzero=true", &r)
+	return r.Results, err
+}


### PR DESCRIPTION
GetPositions() seems to return all positions ever owned (past and
present), but passing the optional nonzero=true query param returns
just the current positions, (which is usually what's wanted?)