### PR TITLE
Make all Client methods have pointer receiver

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ func Dial(s oauth2.TokenSource) (*Client, error) {
 
 // GetAndDecode retrieves from the endpoint and unmarshals resulting json into
 // the provided destination interface, which must be a pointer.
-func (c Client) GetAndDecode(url string, dest interface{}) error {
+func (c *Client) GetAndDecode(url string, dest interface{}) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (e ErrorMap) Error() string {
 
 // DoAndDecode provides useful abstractions around common errors and decoding
 // issues.
-func (c Client) DoAndDecode(req *http.Request, dest interface{}) error {
+func (c *Client) DoAndDecode(req *http.Request, dest interface{}) error {
 	res, err := c.Do(req)
 	if err != nil {
 		return err

--- a/fundamentals.go
+++ b/fundamentals.go
@@ -18,7 +18,7 @@ type Fundamental struct {
 }
 
 // GetFundamentals returns fundemental data for the list of stocks provided.
-func (c Client) GetFundamentals(stocks ...string) ([]Fundamental, error) {
+func (c *Client) GetFundamentals(stocks ...string) ([]Fundamental, error) {
 	url := EPFundamentals + "?symbols=" + strings.Join(stocks, ",")
 	var r struct{ Results []Fundamental }
 	err := c.GetAndDecode(url, &r)

--- a/instrument.go
+++ b/instrument.go
@@ -36,7 +36,7 @@ func (i Instrument) OrderSymbol() string {
 }
 
 // GetInstrument returns an Instrument given a URL
-func (c Client) GetInstrument(instURL string) (*Instrument, error) {
+func (c *Client) GetInstrument(instURL string) (*Instrument, error) {
 	var i Instrument
 	err := c.GetAndDecode(instURL, &i)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c Client) GetInstrument(instURL string) (*Instrument, error) {
 }
 
 // GetInstrumentForSymbol returns an Instrument given a ticker symbol
-func (c Client) GetInstrumentForSymbol(sym string) (*Instrument, error) {
+func (c *Client) GetInstrumentForSymbol(sym string) (*Instrument, error) {
 	var i struct {
 		Results []Instrument
 	}

--- a/positions.go
+++ b/positions.go
@@ -15,7 +15,7 @@ type Position struct {
 }
 
 // GetPositions returns all the positions associated with an account.
-func (c Client) GetPositions(a Account) ([]Position, error) {
+func (c *Client) GetPositions(a Account) ([]Position, error) {
 	return c.GetPositionsParams(a, PositionParams{})
 }
 
@@ -37,7 +37,7 @@ func (p PositionParams) encode() string {
 // GetPositionsParams returns all the positions associated with a count, but
 // passes the encoded PositionsParams object along to the RobinHood API as part
 // of the query string.
-func (c Client) GetPositionsParams(a Account, p PositionParams) ([]Position, error) {
+func (c *Client) GetPositionsParams(a Account, p PositionParams) ([]Position, error) {
 	u, err := url.Parse(a.Positions)
 	if err != nil {
 		return nil, err

--- a/quote.go
+++ b/quote.go
@@ -22,7 +22,7 @@ type Quote struct {
 }
 
 // GetQuote returns all the latest stock quotes for the list of stocks provided
-func (c Client) GetQuote(stocks ...string) ([]Quote, error) {
+func (c *Client) GetQuote(stocks ...string) ([]Quote, error) {
 	url := EPQuotes + "?symbols=" + strings.Join(stocks, ",")
 	var r struct{ Results []Quote }
 	err := c.GetAndDecode(url, &r)


### PR DESCRIPTION
this allow those who want to mock robinhood client for test to create interface like
```
type RHClient interface {
    DoAndDecode(req *http.Request, dest interface{}) error
    GetAccounts() ([]Account, error)
    GetAndDecode(url string, dest interface{}) error
    GetFundamentals(stocks ...string) ([]Fundamental, error)
    GetInstrument(instURL string) (*Instrument, error)
    GetInstrumentForSymbol(sym string) (*Instrument, error)
    GetOptionChains(is ...*Instrument) ([]*OptionChain, error)
    GetOptionsOrders() (json.RawMessage, error)
    GetPortfolios() ([]Portfolio, error)
    GetPositions(a Account) ([]Position, error)
    GetPositionsParams(a Account, p PositionParams) ([]Position, error)
    GetQuote(stocks ...string) ([]Quote, error)
    GetWatchlists() ([]Watchlist, error)
    MarketData(opts ...*OptionInstrument) ([]*MarketData, error)
    Order(i *Instrument, o OrderOpts) (*OrderOutput, error)
    OrderOptions(q *OptionInstrument, o OptionsOrderOpts) (json.RawMessage, error)
    RecentOrders() ([]OrderOutput, error)
}
```

when client take mix mash of pointer and value, it cannot simply implement the interface

thanks :)