### PR TITLE
Run 'lint-install', address lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,204 @@
+# NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
+linters-settings:
+  cyclop:
+    # NOTE: This is a very high transitional threshold
+    max-complexity: 37
+    package-average: 34.0
+    skip-tests: true
+
+  gocognit:
+    # NOTE: This is a very high transitional threshold
+    min-complexity: 98
+
+  dupl:
+    threshold: 200
+
+  goconst:
+    min-len: 4
+    min-occurrences: 5
+    ignore-tests: true
+
+  gosec:
+    excludes:
+      - G107 # Potential HTTP request made with variable url
+      - G204 # Subprocess launched with function call as argument or cmd arguments
+      - G404 # Use of weak random number generator (math/rand instead of crypto/rand
+
+  errorlint:
+    # these are still common in Go: for instance, exit errors.
+    asserts: false
+
+  exhaustive:
+    default-signifies-exhaustive: true
+
+  nestif:
+    min-complexity: 8
+
+  nolintlint:
+    require-explanation: true
+    allow-unused: false
+    require-specific: true
+
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: confusing-naming
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: dot-imports
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: identical-branches
+      - name: if-return
+      - name: import-shadowing
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: struct-tag
+      - name: time-naming
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+      - name: unconditional-recursion
+      - name: waitgroup-by-value
+
+  staticcheck:
+    go: "1.16"
+
+  unused:
+    go: "1.16"
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - cyclop
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # errname is only available in golangci-lint v1.42.0+ - wait until v1.43 is available to settle
+    #- errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - gofumpt
+    - gosec
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    - predeclared
+    # disabling for the initial iteration of the linting tool
+    #- promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+
+  # Disabled linters, due to being misaligned with Go practices
+  # - exhaustivestruct
+  # - gochecknoglobals
+  # - gochecknoinits
+  # - goconst
+  # - godox
+  # - goerr113
+  # - gomnd
+  # - lll
+  # - nlreturn
+  # - testpackage
+  # - wsl
+  # Disabled linters, due to not being relevant to our code base:
+  # - maligned
+  # - prealloc "For most programs usage of prealloc will be a premature optimization."
+  # Disabled linters due to bad error messages or bugs
+  # - tagliatelle
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - errcheck
+        - forcetypeassert
+        - gocyclo
+        - gosec
+        - noctx
+
+    - path: .*cmd.*
+      linters:
+        - noctx
+
+    - path: main\.go
+      linters:
+        - noctx
+
+    - path: .*cmd.*
+      text: "deep-exit"
+
+    - path: main\.go
+      text: "deep-exit"
+
+    # This check is of questionable value
+    - linters:
+        - tparallel
+      text: "call t.Parallel on the top level as well as its subtests"
+
+  # Don't hide lint issues just because there are many of them
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+
+# BEGIN: lint-install .
+# http://github.com/tinkerbell/lint-install
+
+GOLINT_VERSION ?= v1.42.0
+
+
+LINT_OS := $(shell uname)
+LINT_ARCH := $(shell uname -m)
+LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
+ifeq ($(LINT_OS),Darwin)
+	ifeq ($(LINT_ARCH),arm64)
+		LINT_ARCH=x86_64
+	endif
+endif
+
+
+GOLINT_CONFIG:=$(LINT_ROOT)/.golangci.yml
+
+lint: out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run
+
+fix: out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run --fix
+
+out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+	mkdir -p out/linters
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+
+# END: lint-install .

--- a/account.go
+++ b/account.go
@@ -2,7 +2,7 @@ package robinhood
 
 import "context"
 
-// Account holds the basic account details relevant to the RobinHood API
+// Account holds the basic account details relevant to the RobinHood API.
 type Account struct {
 	Meta
 	AccountNumber              string         `json:"account_number"`
@@ -28,7 +28,7 @@ type Account struct {
 	WithdrawalHalted           bool           `json:"withdrawal_halted"`
 }
 
-// CashBalances reflect the amount of cash available
+// CashBalances reflect the amount of cash available.
 type CashBalances struct {
 	Meta
 	BuyingPower                float64 `json:"buying_power,string"`
@@ -39,7 +39,7 @@ type CashBalances struct {
 	UnsettledFunds             float64 `json:"unsettled_funds,string"`
 }
 
-// MarginBalances reflect the balance available in margin accounts
+// MarginBalances reflect the balance available in margin accounts.
 type MarginBalances struct {
 	Meta
 	Cash                              float64 `json:"cash,string"`
@@ -68,14 +68,14 @@ func (c *Client) GetAccounts(ctx context.Context) ([]Account, error) {
 	return r.Results, err
 }
 
-// CryptoAccount holds the basic account details relevant to robinhood API
+// CryptoAccount holds the basic account details relevant to robinhood API.
 type CryptoAccount struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
 	UserID string `json:"user_id"`
 }
 
-// GetCryptoAccounts will return associated cryto account
+// GetCryptoAccounts will return associated cryto account.
 func (c *Client) GetCryptoAccounts(ctx context.Context) ([]CryptoAccount, error) {
 	var r struct{ Results []CryptoAccount }
 	err := c.GetAndDecode(ctx, EPCryptoAccount, &r)

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Endpoints for the Robinhood API
+// Endpoints for the Robinhood API.
 const (
 	EPBase                = "https://api.robinhood.com/"
 	EPCryptoBase          = "https://nummus.robinhood.com/"
@@ -53,6 +53,10 @@ func Dial(ctx context.Context, s oauth2.TokenSource) (*Client, error) {
 	}
 
 	a, err := c.GetAccounts(ctx)
+	if err != nil {
+		return c, err
+	}
+
 	if len(a) > 0 {
 		c.Account = &a[0]
 	}
@@ -68,7 +72,7 @@ func Dial(ctx context.Context, s oauth2.TokenSource) (*Client, error) {
 // GetAndDecode retrieves from the endpoint and unmarshals resulting json into
 // the provided destination interface, which must be a pointer.
 func (c *Client) GetAndDecode(ctx context.Context, url string, dest interface{}) error {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return err
 	}
@@ -76,7 +80,7 @@ func (c *Client) GetAndDecode(ctx context.Context, url string, dest interface{})
 	return c.DoAndDecode(ctx, req, dest)
 }
 
-// ErrorMap encapsulates the helpful error messages returned by the API server
+// ErrorMap encapsulates the helpful error messages returned by the API server.
 type ErrorMap map[string]interface{}
 
 func (e ErrorMap) Error() string {

--- a/creds.go
+++ b/creds.go
@@ -39,9 +39,9 @@ func (c *CredsCacher) Token() (*oauth2.Token, error) {
 
 	mustLogin := false
 
-	err := os.MkdirAll(path.Dir(c.Path), 0750)
+	err := os.MkdirAll(path.Dir(c.Path), 0o750)
 	if err != nil {
-		return nil, fmt.Errorf("error creating path for token: %s", err)
+		return nil, fmt.Errorf("error creating path for token: %w", err)
 	}
 
 	_, err = os.Stat(c.Path)
@@ -72,7 +72,7 @@ func (c *CredsCacher) Token() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	f, err := os.OpenFile(c.Path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
+	f, err := os.OpenFile(c.Path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o640)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto_order.go
+++ b/crypto_order.go
@@ -3,18 +3,16 @@ package robinhood
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-
-	"encoding/json"
-
-	"net/http"
 )
 
-// CryptoOrder is the payload to create a crypto currency order
+// CryptoOrder is the payload to create a crypto currency order.
 type CryptoOrder struct {
 	AccountID      string  `json:"account_id,omitempty"`
 	CurrencyPairID string  `json:"currency_pair_id,omitempty"`
@@ -26,7 +24,7 @@ type CryptoOrder struct {
 	Type           string  `json:"type,omitempty"`
 }
 
-// CryptoOrderOutput holds the response from api
+// CryptoOrderOutput holds the response from api.
 type CryptoOrderOutput struct {
 	Meta
 	Account            string        `json:"account"`
@@ -50,7 +48,7 @@ type CryptoOrderOutput struct {
 	client *Client
 }
 
-// CryptoOrderOpts encapsulates differences between order types
+// CryptoOrderOpts encapsulates differences between order types.
 type CryptoOrderOpts struct {
 	Side            OrderSide
 	Type            OrderType
@@ -62,9 +60,9 @@ type CryptoOrderOpts struct {
 	Stop, Force     bool
 }
 
-// CryptoOrder will actually place the order
+// CryptoOrder will actually place the order.
 func (c *Client) CryptoOrder(ctx context.Context, cryptoPair CryptoCurrencyPair, o CryptoOrderOpts) (*CryptoOrderOutput, error) {
-	var quantity = math.Round(o.AmountInDollars / o.Price)
+	quantity := math.Round(o.AmountInDollars / o.Price)
 	a := CryptoOrder{
 		AccountID:      c.CryptoAccount.ID,
 		CurrencyPairID: cryptoPair.ID,
@@ -77,12 +75,11 @@ func (c *Client) CryptoOrder(ctx context.Context, cryptoPair CryptoCurrencyPair,
 	}
 
 	payload, err := json.Marshal(a)
-
 	if err != nil {
 		return nil, err
 	}
 
-	post, err := http.NewRequest("POST", EPCryptoOrders, bytes.NewReader(payload))
+	post, err := http.NewRequestWithContext(ctx, "POST", EPCryptoOrders, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("could not create Crypto http.Request: %w", err)
 	}

--- a/currency_pairs.go
+++ b/currency_pairs.go
@@ -3,11 +3,9 @@ package robinhood
 import (
 	"context"
 	"errors"
-
 	"fmt"
 )
 
-// CryptoCurrencyPair represent all availabe crypto currencies and whether they are tradeable or not
 type CryptoCurrencyPair struct {
 	CyrptoAssetCurrency    AssetCurrency `json:"asset_currency"`
 	ID                     string        `json:"id"`
@@ -20,7 +18,7 @@ type CryptoCurrencyPair struct {
 	Tradability            string        `json:"tradability"`
 }
 
-// QuoteCurrency holds info about currency you can use to buy the cyrpto currency
+// QuoteCurrency holds info about currency you can use to buy the cyrpto currency.
 type QuoteCurrency struct {
 	Code      string  `json:"code"`
 	ID        string  `json:"id"`
@@ -29,7 +27,7 @@ type QuoteCurrency struct {
 	Type      string  `json:"type"`
 }
 
-// AssetCurrency has code and id of cryptocurrency
+// AssetCurrency has code and id of cryptocurrency.
 type AssetCurrency struct {
 	BrandColor string  `json:"brand_color"`
 	Code       string  `json:"code"`
@@ -38,7 +36,7 @@ type AssetCurrency struct {
 	Name       string  `json:"name"`
 }
 
-// GetCryptoCurrencyPairs will give which crypto currencies are tradeable and corresponding ids
+// GetCryptoCurrencyPairs will give which crypto currencies are tradeable and corresponding ids.
 func (c *Client) GetCryptoCurrencyPairs(ctx context.Context) ([]CryptoCurrencyPair, error) {
 	var r struct{ Results []CryptoCurrencyPair }
 	err := c.GetAndDecode(ctx, EPCryptoCurrencyPairs, &r)
@@ -46,11 +44,11 @@ func (c *Client) GetCryptoCurrencyPairs(ctx context.Context) ([]CryptoCurrencyPa
 }
 
 // GetCryptoInstrument will take standard crypto symbol and return usable information
-// to place the order
+// to place the order.
 func (c *Client) GetCryptoInstrument(ctx context.Context, symbol string) (*CryptoCurrencyPair, error) {
 	allPairs, err := c.GetCryptoCurrencyPairs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("call failed with error: %v", err.Error())
+		return nil, fmt.Errorf("call failed with error: %w", err)
 	}
 
 	for _, pair := range allPairs {

--- a/instrument.go
+++ b/instrument.go
@@ -22,7 +22,7 @@ type Instrument struct {
 	MinTickSize           interface{} `json:"min_tick_size"`
 	Name                  string      `json:"name"`
 	Quote                 string      `json:"quote"`
-	RhsTradability        string      `json:"rhs_tradability"`
+	RHSTradability        string      `json:"rhs_tradability"`
 	SimpleName            interface{} `json:"simple_name"`
 	Splits                string      `json:"splits"`
 	State                 string      `json:"state"`
@@ -42,7 +42,7 @@ func (i Instrument) OrderSymbol() string {
 	return i.Symbol
 }
 
-// GetInstrument returns an Instrument given a URL
+// GetInstrument returns an Instrument given a URL.
 func (c *Client) GetInstrument(ctx context.Context, instURL string) (*Instrument, error) {
 	var i Instrument
 	err := c.GetAndDecode(ctx, instURL, &i)
@@ -52,7 +52,7 @@ func (c *Client) GetInstrument(ctx context.Context, instURL string) (*Instrument
 	return &i, err
 }
 
-// GetInstrumentForSymbol returns an Instrument given a ticker symbol
+// GetInstrumentForSymbol returns an Instrument given a ticker symbol.
 func (c *Client) GetInstrumentForSymbol(ctx context.Context, sym string) (*Instrument, error) {
 	var i struct {
 		Results []Instrument

--- a/marketdata.go
+++ b/marketdata.go
@@ -6,8 +6,8 @@ import (
 )
 
 type EntryPrice struct {
-	Amount        string
-	Currency_code string
+	Amount       string
+	CurrencyCode string `json:"currency_code"`
 }
 
 type PriceBookEntry struct {
@@ -24,7 +24,7 @@ type PriceBookData struct {
 	UpdatedAt    string `json:"updated_at"`
 }
 
-// Pricebook get the current snapshot of the pricebook data
+// Pricebook get the current snapshot of the pricebook data.
 func (c *Client) Pricebook(ctx context.Context, instrumentID string) (*PriceBookData, error) {
 	var out PriceBookData
 	err := c.GetAndDecode(ctx, fmt.Sprintf("%spricebook/snapshots/%s/", EPMarket, instrumentID), &out)

--- a/oauth.go
+++ b/oauth.go
@@ -1,6 +1,7 @@
 package robinhood
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,15 +16,15 @@ import (
 // DefaultClientID is used by the website.
 const DefaultClientID = "c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS"
 
-// OAuth implements oauth2 using the robinhood implementation
+// OAuth implements oauth2 using the robinhood implementation.
 type OAuth struct {
 	Endpoint, ClientID, Username, Password, MFA string
 }
 
 // ErrMFARequired indicates the MFA was required but not provided.
-var ErrMFARequired = fmt.Errorf("Two Factor Auth code required and not supplied")
+var ErrMFARequired = fmt.Errorf("two-factor auth code required and not supplied")
 
-// Token implements TokenSource
+// Token implements TokenSource.
 func (p *OAuth) Token() (*oauth2.Token, error) {
 	cliID := p.ClientID
 	if cliID == "" {
@@ -46,11 +47,7 @@ func (p *OAuth) Token() (*oauth2.Token, error) {
 		v.Add("mfa_code", p.MFA)
 	}
 
-	req, err := http.NewRequest(
-		"POST",
-		u.String(),
-		strings.NewReader(v.Encode()),
-	)
+	req, err := http.NewRequestWithContext(context.TODO(), "POST", u.String(), strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create request")
 	}

--- a/optiondirection.go
+++ b/optiondirection.go
@@ -6,16 +6,16 @@ import (
 )
 
 // OptionDirection is a type for whether an option order is opening or closing
-// an option position
+// an option position.
 type OptionDirection int
 
-// MarshalJSON implements json.Marshaler
+// MarshalJSON implements json.Marshaler.
 func (o OptionDirection) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", strings.ToLower(o.String()))), nil
 }
 
 //go:generate stringer -type OptionDirection
-// The two directions
+// The two directions.
 const (
 	Debit OptionDirection = iota
 	Credit

--- a/options-order.go
+++ b/options-order.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// OptionsOrderOpts encapsulates common Options order choices
+// OptionsOrderOpts encapsulates common Options order choices.
 type OptionsOrderOpts struct {
 	Quantity    float64
 	Price       float64
@@ -19,7 +19,7 @@ type OptionsOrderOpts struct {
 	Side        OrderSide
 }
 
-// optionInput is the input object to the RobinHood API
+// optionInput is the input object to the RobinHood API.
 type optionInput struct {
 	Account                string          `json:"account"`
 	Direction              OptionDirection `json:"direction"`
@@ -73,7 +73,7 @@ func (c *Client) OrderOptions(ctx context.Context, q *OptionInstrument, o Option
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", EPOptions+"orders/", bytes.NewReader(bs))
+	req, err := http.NewRequestWithContext(ctx, "POST", EPOptions+"orders/", bytes.NewReader(bs))
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (c *Client) OrderOptions(ctx context.Context, q *OptionInstrument, o Option
 	return out, nil
 }
 
-// GetOptionsOrders returns all outstanding options orders
+// GetOptionsOrders returns all outstanding options orders.
 func (c *Client) GetOptionsOrders(ctx context.Context) (json.RawMessage, error) {
 	var o json.RawMessage
 	err := c.GetAndDecode(ctx, EPOptions+"orders/", &o)
@@ -96,5 +96,4 @@ func (c *Client) GetOptionsOrders(ctx context.Context) (json.RawMessage, error) 
 	}
 
 	return o, nil
-
 }

--- a/options.go
+++ b/options.go
@@ -13,12 +13,12 @@ import (
 
 const dateFormat = "2006-01-02"
 
-// Date is a specific json time format for dates only
+// Date is a specific json time format for dates only.
 type Date struct {
 	time.Time
 }
 
-// NewDate returns a new Date in the local time zone
+// NewDate returns a new Date in the local time zone.
 func NewDate(y, m, d int) Date {
 	return Date{time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.Local)}
 }
@@ -32,12 +32,12 @@ func (d Date) String() string {
 	return d.Format(dateFormat)
 }
 
-// MarshalJSON implements json.Marshaler
+// MarshalJSON implements json.Marshaler.
 func (d Date) MarshalJSON() ([]byte, error) {
 	return []byte("\"" + d.String() + "\""), nil
 }
 
-// UnmarshalJSON implements json.Unmarshaler
+// UnmarshalJSON implements json.Unmarshaler.
 func (d *Date) UnmarshalJSON(bs []byte) error {
 	t, err := time.Parse(dateFormat, strings.Trim(strings.TrimSpace(string(bs)), "\""))
 	if err != nil {
@@ -47,7 +47,7 @@ func (d *Date) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// GetOptionChains returns options for the given instruments
+// GetOptionChains returns options for the given instruments.
 func (c *Client) GetOptionChains(ctx context.Context, is ...*Instrument) ([]*OptionChain, error) {
 	s := []string{}
 	for _, inst := range is {
@@ -68,7 +68,7 @@ func (c *Client) GetOptionChains(ctx context.Context, is ...*Instrument) ([]*Opt
 	return res.Results, nil
 }
 
-// OptionChain represents the data the RobinHood API holds behind options chains
+// OptionChain represents the data the RobinHood API holds behind options chains.
 type OptionChain struct {
 	CanOpenPosition       bool                   `json:"can_open_position"`
 	CashComponent         interface{}            `json:"cash_component"`
@@ -148,14 +148,14 @@ type MinTicks struct {
 }
 
 // UnderlyingInstrument is the type that represents a link from an option back
-// to its standard financial instrument (stock)
+// to its standard financial instrument (stock).
 type UnderlyingInstrument struct {
 	ID         string `json:"id"`
 	Instrument string `json:"instrument"`
 	Quantity   int    `json:"quantity"`
 }
 
-// An OptionInstrument can have a quote
+// An OptionInstrument can have a quote.
 type OptionInstrument struct {
 	ChainID        string   `json:"chain_id"`
 	ChainSymbol    string   `json:"chain_symbol"`
@@ -171,8 +171,6 @@ type OptionInstrument struct {
 	Type           string   `json:"type"`
 	UpdatedAt      string   `json:"updated_at"`
 	URL            string   `json:"url"`
-
-	c *Client
 }
 
 // MarketData is the current pricing data and greeks for a given option at a
@@ -215,7 +213,7 @@ func OIsForDate(os []*OptionInstrument, d Date) []*OptionInstrument {
 	return out
 }
 
-// MarketData returns market data for all the listed Option instruments
+// MarketData returns market data for all the listed Option instruments.
 func (c *Client) MarketData(ctx context.Context, opts ...*OptionInstrument) ([]*MarketData, error) {
 	is := make([]string, len(opts))
 

--- a/order.go
+++ b/order.go
@@ -11,25 +11,25 @@ import (
 	"github.com/pkg/errors"
 )
 
-// OrderSide is which side of the trade an order is on
+// OrderSide is which side of the trade an order is on.
 type OrderSide int
 
-// MarshalJSON implements json.Marshaler
+// MarshalJSON implements json.Marshaler.
 func (o OrderSide) MarshalJSON() ([]byte, error) {
 	return []byte("\"" + strings.ToLower(o.String()) + "\""), nil
 }
 
 //go:generate stringer -type OrderSide
-// Buy/Sell
+// Buy/Sell.
 const (
 	Sell OrderSide = iota + 1
 	Buy
 )
 
-// OrderType represents a Limit or Market order
+// OrderType represents a Limit or Market order.
 type OrderType int
 
-// MarshalJSON implements json.Marshaler
+// MarshalJSON implements json.Marshaler.
 func (o OrderType) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", strings.ToLower(o.String()))), nil
 }
@@ -41,7 +41,7 @@ const (
 	Limit
 )
 
-// OrderOpts encapsulates differences between order types
+// OrderOpts encapsulates differences between order types.
 type OrderOpts struct {
 	Side          OrderSide
 	Type          OrderType
@@ -96,7 +96,7 @@ func (c *Client) Order(ctx context.Context, i *Instrument, o OrderOpts) (*OrderO
 		return nil, err
 	}
 
-	post, err := http.NewRequest("POST", EPOrders, bytes.NewReader(bs))
+	post, err := http.NewRequestWithContext(ctx, "POST", EPOrders, bytes.NewReader(bs))
 	if err != nil {
 		return nil, fmt.Errorf("error creating POST http.Request: %w", err)
 	}
@@ -113,7 +113,7 @@ func (c *Client) Order(ctx context.Context, i *Instrument, o OrderOpts) (*OrderO
 	return &out, nil
 }
 
-// OrderOutput is the response from the Order api
+// OrderOutput is the response from the Order api.
 type OrderOutput struct {
 	Meta
 	Account                string        `json:"account"`
@@ -148,9 +148,9 @@ func (o *OrderOutput) Update(ctx context.Context) error {
 	return o.client.GetAndDecode(ctx, o.URL, o)
 }
 
-// Cancel attempts to cancel an odrer
+// Cancel attempts to cancel an odrer.
 func (o OrderOutput) Cancel(ctx context.Context) error {
-	post, err := http.NewRequest("POST", o.CancelURL, nil)
+	post, err := http.NewRequestWithContext(ctx, "POST", o.CancelURL, nil)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,6 @@ func (c *Client) AllOrders(ctx context.Context) ([]OrderOutput, error) {
 			Next    string
 		}
 		err := c.GetAndDecode(ctx, url, &tmp)
-
 		if err != nil {
 			return o.Results, err
 		}

--- a/portfolios.go
+++ b/portfolios.go
@@ -2,7 +2,7 @@ package robinhood
 
 import "context"
 
-// Portfolio holds all information regarding the portfolio
+// Portfolio holds all information regarding the portfolio.
 type Portfolio struct {
 	Account                                string  `json:"account"`
 	AdjustedEquityPreviousClose            float64 `json:"adjusted_equity_previous_close,string"`
@@ -24,7 +24,7 @@ type Portfolio struct {
 	WithdrawableAmount                     float64 `json:"withdrawable_amount,string"`
 }
 
-// CryptoPortfolio returns all the portfolio associated with a client's account
+// CryptoPortfolio returns all the portfolio associated with a client's account.
 type CryptoPortfolio struct {
 	AccountID                string  `json:"account_id"`
 	Equity                   float64 `json:"equity,string"`
@@ -35,17 +35,17 @@ type CryptoPortfolio struct {
 }
 
 // GetPortfolios returns all the portfolios associated with a client's
-// credentials and accounts
+// credentials and accounts.
 func (c *Client) GetPortfolios(ctx context.Context) ([]Portfolio, error) {
 	var p struct{ Results []Portfolio }
 	err := c.GetAndDecode(ctx, EPPortfolios, &p)
 	return p.Results, err
 }
 
-// GetCryptoPortfolios returns crypto portfolio info
+// GetCryptoPortfolios returns crypto portfolio info.
 func (c *Client) GetCryptoPortfolios(ctx context.Context) (CryptoPortfolio, error) {
 	var p CryptoPortfolio
-	var portfolioURL = EPCryptoPortfolio + c.CryptoAccount.ID
+	portfolioURL := EPCryptoPortfolio + c.CryptoAccount.ID
 	err := c.GetAndDecode(ctx, portfolioURL, &p)
 	return p, err
 }

--- a/positions.go
+++ b/positions.go
@@ -30,13 +30,13 @@ type OptionPostion struct {
 	Legs                     []LegPosition `json:"legs"`
 	IntradayQuantity         string        `json:"intraday_quantity"`
 	UpdatedAt                string        `json:"updated_at"`
-	Id                       string        `json:"id"`
+	ID                       string        `json:"id"`
 	IntradayAverageOpenPrice string        `json:"intraday_average_open_price"`
 	CreatedAt                string        `json:"created_at"`
 }
 
 type LegPosition struct {
-	Id             string `json:"id"`
+	ID             string `json:"id"`
 	Position       string `json:"position"`
 	PositionType   string `json:"position_type"`
 	Option         string `json:"option"`
@@ -64,7 +64,7 @@ type PositionParams struct {
 	NonZero bool
 }
 
-// Encode returns the query string associated with the requested parameters
+// Encode returns the query string associated with the requested parameters.
 func (p PositionParams) encode() string {
 	v := url.Values{}
 	if p.NonZero {

--- a/quote.go
+++ b/quote.go
@@ -6,7 +6,7 @@ import (
 )
 
 // A Quote is a representation of the data returned by the Robinhood API for
-// current stock quotes
+// current stock quotes.
 type Quote struct {
 	AdjustedPreviousClose       float64 `json:"adjusted_previous_close,string"`
 	AskPrice                    float64 `json:"ask_price,string"`
@@ -22,7 +22,7 @@ type Quote struct {
 	UpdatedAt                   string  `json:"updated_at"`
 }
 
-// GetQuote returns all the latest stock quotes for the list of stocks provided
+// GetQuote returns all the latest stock quotes for the list of stocks provided.
 func (c *Client) GetQuote(ctx context.Context, stocks ...string) ([]Quote, error) {
 	url := EPQuotes + "?symbols=" + strings.Join(stocks, ",")
 	var r struct{ Results []Quote }
@@ -30,7 +30,7 @@ func (c *Client) GetQuote(ctx context.Context, stocks ...string) ([]Quote, error
 	return r.Results, err
 }
 
-// Price returns the proper stock price even after hours
+// Price returns the proper stock price even after hours.
 func (q Quote) Price() float64 {
 	if IsRegularTradingTime() {
 		return q.LastTradePrice

--- a/time-in-force.go
+++ b/time-in-force.go
@@ -8,13 +8,13 @@ import (
 // TimeInForce is the time in force for an order.
 type TimeInForce int
 
-// MarshalJSON implements json.Marshaler
+// MarshalJSON implements json.Marshaler.
 func (t TimeInForce) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", strings.ToLower(t.String()))), nil
 }
 
 //go:generate stringer -type=TimeInForce
-// Well-known values for TimeInForce
+// Well-known values for TimeInForce.
 const (
 	// GTC means Good 'Til Cancelled.
 	GTC TimeInForce = iota

--- a/times.go
+++ b/times.go
@@ -36,22 +36,16 @@ func nyMinute() int {
 	return MinuteOfDay(time.Now().In(nyLoc()))
 }
 
-// isWeekday returns whether or not the given time.Time is a weekday.
-func isWeekday(t time.Time) bool {
+// IsWeekday returns whether or not the given time.Time is a weekday.
+func IsWeekday(t time.Time) bool {
 	wd := t.Weekday()
 	return wd != time.Saturday && wd != time.Sunday
-}
-
-// IsWeekDay returns whether the given time is a regular
-// weekday
-func IsWeekDay(t time.Time) bool {
-	return isWeekday(time.Now())
 }
 
 // NextWeekday returns the next weekday.
 func NextWeekday() time.Time {
 	d := time.Now().AddDate(0, 0, 1)
-	for !isWeekday(d) {
+	for !IsWeekday(d) {
 		d = d.AddDate(0, 0, 1)
 	}
 	return d
@@ -98,30 +92,30 @@ func NextMarketOpen() time.Time {
 // NextMarketExtendedOpen returns the time of the next extended opening time,
 // when stock equity may begin to fluctuate again.
 func NextMarketExtendedOpen() time.Time {
-	return nextWeekdayHourMinuteNY(HrExtendedOpen, 00)
+	return nextWeekdayHourMinuteNY(HrExtendedOpen, 0o0)
 }
 
 // NextRobinhoodExtendedOpen returns the time of the next robinhood extended
 // opening time, when robinhood users can make trades.
 func NextRobinhoodExtendedOpen() time.Time {
-	return nextWeekdayHourMinuteNY(HrRHExtendedOpen, 00)
+	return nextWeekdayHourMinuteNY(HrRHExtendedOpen, 0o0)
 }
 
 // NextMarketClose returns the time of the next market close.
 func NextMarketClose() time.Time {
-	return nextWeekdayHourMinuteNY(HrClose, 00)
+	return nextWeekdayHourMinuteNY(HrClose, 0o0)
 }
 
 // NextRobinhoodExtendedClose returns the time of the next robinhood extended
 // closing time, when robinhood users must place their last extended-hours
 // trade.
 func NextRobinhoodExtendedClose() time.Time {
-	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 00)
+	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 0o0)
 }
 
 // NextMarketExtendedClose returns the time of the next extended market close,
 // when stock equity numbers will stop being updated until the next extended
 // open.
 func NextMarketExtendedClose() time.Time {
-	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 00)
+	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 0o0)
 }

--- a/times.go
+++ b/times.go
@@ -92,30 +92,30 @@ func NextMarketOpen() time.Time {
 // NextMarketExtendedOpen returns the time of the next extended opening time,
 // when stock equity may begin to fluctuate again.
 func NextMarketExtendedOpen() time.Time {
-	return nextWeekdayHourMinuteNY(HrExtendedOpen, 0o0)
+	return nextWeekdayHourMinuteNY(HrExtendedOpen, 0)
 }
 
 // NextRobinhoodExtendedOpen returns the time of the next robinhood extended
 // opening time, when robinhood users can make trades.
 func NextRobinhoodExtendedOpen() time.Time {
-	return nextWeekdayHourMinuteNY(HrRHExtendedOpen, 0o0)
+	return nextWeekdayHourMinuteNY(HrRHExtendedOpen, 0)
 }
 
 // NextMarketClose returns the time of the next market close.
 func NextMarketClose() time.Time {
-	return nextWeekdayHourMinuteNY(HrClose, 0o0)
+	return nextWeekdayHourMinuteNY(HrClose, 0)
 }
 
 // NextRobinhoodExtendedClose returns the time of the next robinhood extended
 // closing time, when robinhood users must place their last extended-hours
 // trade.
 func NextRobinhoodExtendedClose() time.Time {
-	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 0o0)
+	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 0)
 }
 
 // NextMarketExtendedClose returns the time of the next extended market close,
 // when stock equity numbers will stop being updated until the next extended
 // open.
 func NextMarketExtendedClose() time.Time {
-	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 0o0)
+	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 0)
 }

--- a/watchlists.go
+++ b/watchlists.go
@@ -13,7 +13,7 @@ type Watchlist struct {
 	URL  string `json:"url"`
 	User string `json:"user"`
 
-	Client *Client `json:",ignore"`
+	Client *Client `json:"-"`
 }
 
 // GetWatchlists retrieves the watchlists for a given set of credentials/accounts.


### PR DESCRIPTION
I wanted to clear up some lint problems before making other contributions, so here is my first. 

This adds a `make lint` target and vetted `.golangcilint.yaml` file. If these aren't useful to you, I'm happy to remove them from the PR.

## Issues Resolved

```
account.go:5:73: Comment should end in a period (godot)
// Account holds the basic account details relevant to the RobinHood API
                                                                        ^
account.go:31:53: Comment should end in a period (godot)
// CashBalances reflect the amount of cash available
                                                    ^
account.go:42:67: Comment should end in a period (godot)
// MarginBalances reflect the balance available in margin accounts
                                                                  ^
account.go:71:75: Comment should end in a period (godot)
// CryptoAccount holds the basic account details relevant to robinhood API
                                                                          ^
account.go:78:58: Comment should end in a period (godot)
// GetCryptoAccounts will return associated cryto account
                                                         ^
client.go:16:35: Comment should end in a period (godot)
// Endpoints for the Robinhood API
                                  ^
client.go:55:5: ineffectual assignment to err (ineffassign)
	a, err := c.GetAccounts(ctx)
	   ^
client.go:71:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
	req, err := http.NewRequest("GET", url, nil)
	                           ^
client.go:79:79: Comment should end in a period (godot)
// ErrorMap encapsulates the helpful error messages returned by the API server
                                                                              ^
creds.go:42: File is not `gofumpt`-ed (gofumpt)
	err := os.MkdirAll(path.Dir(c.Path), 0750)
creds.go:44:63: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
		return nil, fmt.Errorf("error creating path for token: %s", err)
		                                                            ^
creds.go:75: File is not `gofumpt`-ed (gofumpt)
	f, err := os.OpenFile(c.Path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
crypto_order.go:5: File is not `gofumpt`-ed (gofumpt)
	"context"
crypto_order.go:7: File is not `gofumpt`-ed (gofumpt)
	"math"
crypto_order.go:11: File is not `gofumpt`-ed (gofumpt)

	"encoding/json"

	"net/http"
crypto_order.go:17:64: Comment should end in a period (godot)
// CryptoOrder is the payload to create a crypto currency order
                                                               ^
crypto_order.go:29:49: Comment should end in a period (godot)
// CryptoOrderOutput holds the response from api
                                                ^
crypto_order.go:53:64: Comment should end in a period (godot)
// CryptoOrderOpts encapsulates differences between order types
                                                               ^
crypto_order.go:65:45: Comment should end in a period (godot)
// CryptoOrder will actually place the order
                                            ^
crypto_order.go:67: File is not `gofumpt`-ed (gofumpt)
	var quantity = math.Round(o.AmountInDollars / o.Price)
crypto_order.go:80: File is not `gofumpt`-ed (gofumpt)

crypto_order.go:85:30: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
	post, err := http.NewRequest("POST", EPCryptoOrders, bytes.NewReader(payload))
	                            ^
currency_pairs.go:6: File is not `gofumpt`-ed (gofumpt)

currency_pairs.go:10:101: Comment should end in a period (godot)
// CryptoCurrencyPair represent all availabe crypto currencies and whether they are tradeable or not
                                                                                                    ^
currency_pairs.go:23:82: Comment should end in a period (godot)
// QuoteCurrency holds info about currency you can use to buy the cyrpto currency
                                                                                 ^
currency_pairs.go:32:51: Comment should end in a period (godot)
// AssetCurrency has code and id of cryptocurrency
                                                  ^
currency_pairs.go:41:96: Comment should end in a period (godot)
// GetCryptoCurrencyPairs will give which crypto currencies are tradeable and corresponding ids
                                                                                               ^
currency_pairs.go:49:22: Comment should end in a period (godot)
// to place the order
                     ^
currency_pairs.go:53:56: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
		return nil, fmt.Errorf("call failed with error: %v", err.Error())
		                                                     ^
instrument.go:25:2: var-naming: struct field RhsTradability should be RHSTradability (revive)
	RhsTradability        string      `json:"rhs_tradability"`
	^
instrument.go:45:51: Comment should end in a period (godot)
// GetInstrument returns an Instrument given a URL
                                                  ^
instrument.go:55:70: Comment should end in a period (godot)
// GetInstrumentForSymbol returns an Instrument given a ticker symbol
                                                                     ^
marketdata.go:10:2: var-naming: don't use underscores in Go names; struct field Currency_code should be CurrencyCode (revive)
	Currency_code string
	^
marketdata.go:27:60: Comment should end in a period (godot)
// Pricebook get the current snapshot of the pricebook data
                                                           ^
oauth.go:18:62: Comment should end in a period (godot)
// OAuth implements oauth2 using the robinhood implementation
                                                             ^
oauth.go:24:22: ST1005: error strings should not be capitalized (stylecheck)
var ErrMFARequired = fmt.Errorf("Two Factor Auth code required and not supplied")
                     ^
oauth.go:26:32: Comment should end in a period (godot)
// Token implements TokenSource
                               ^
oauth.go:49:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
	req, err := http.NewRequest(
	                           ^
optiondirection.go:9:22: Comment should end in a period (godot)
// an option position
                     ^
optiondirection.go:12:41: Comment should end in a period (godot)
// MarshalJSON implements json.Marshaler
                                        ^
optiondirection.go:18:22: Comment should end in a period (godot)
// The two directions
                     ^
options-order.go:12:62: Comment should end in a period (godot)
// OptionsOrderOpts encapsulates common Options order choices
                                                             ^
options-order.go:22:56: Comment should end in a period (godot)
// optionInput is the input object to the RobinHood API
                                                       ^
options-order.go:76:29: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
	req, err := http.NewRequest("POST", EPOptions+"orders/", bytes.NewReader(bs))
	                           ^
options-order.go:90:59: Comment should end in a period (godot)
// GetOptionsOrders returns all outstanding options orders
                                                          ^
options-order.go:99: File is not `gofumpt`-ed (gofumpt)

options.go:16:54: Comment should end in a period (godot)
// Date is a specific json time format for dates only
                                                     ^
options.go:21:53: Comment should end in a period (godot)
// NewDate returns a new Date in the local time zone
                                                    ^
options.go:35:41: Comment should end in a period (godot)
// MarshalJSON implements json.Marshaler
                                        ^
options.go:40:45: Comment should end in a period (godot)
// UnmarshalJSON implements json.Unmarshaler
                                            ^
options.go:50:61: Comment should end in a period (godot)
// GetOptionChains returns options for the given instruments
                                                            ^
options.go:71:81: Comment should end in a period (godot)
// OptionChain represents the data the RobinHood API holds behind options chains
                                                                                ^
options.go:151:48: Comment should end in a period (godot)
// to its standard financial instrument (stock)
                                               ^
options.go:158:40: Comment should end in a period (godot)
// An OptionInstrument can have a quote
                                       ^
options.go:175:2: `c` is unused (structcheck)
	c *Client
	^
options.go:218:72: Comment should end in a period (godot)
// MarketData returns market data for all the listed Option instruments
                                                                       ^
order.go:14:55: Comment should end in a period (godot)
// OrderSide is which side of the trade an order is on
                                                      ^
order.go:17:41: Comment should end in a period (godot)
// MarshalJSON implements json.Marshaler
                                        ^
order.go:23:12: Comment should end in a period (godot)
// Buy/Sell
           ^
order.go:29:48: Comment should end in a period (godot)
// OrderType represents a Limit or Market order
                                               ^
order.go:32:41: Comment should end in a period (godot)
// MarshalJSON implements json.Marshaler
                                        ^
order.go:44:58: Comment should end in a period (godot)
// OrderOpts encapsulates differences between order types
                                                         ^
order.go:99:30: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
	post, err := http.NewRequest("POST", EPOrders, bytes.NewReader(bs))
	                            ^
order.go:116:50: Comment should end in a period (godot)
// OrderOutput is the response from the Order api
                                                 ^
order.go:151:38: Comment should end in a period (godot)
// Cancel attempts to cancel an odrer
                                     ^
order.go:153:30: should rewrite http.NewRequestWithContext or add (*Request).WithContext (noctx)
	post, err := http.NewRequest("POST", o.CancelURL, nil)
	                            ^
order.go:206: File is not `gofumpt`-ed (gofumpt)

portfolios.go:5:59: Comment should end in a period (godot)
// Portfolio holds all information regarding the portfolio
                                                          ^
portfolios.go:27:80: Comment should end in a period (godot)
// CryptoPortfolio returns all the portfolio associated with a client's account
                                                                               ^
portfolios.go:38:28: Comment should end in a period (godot)
// credentials and accounts
                           ^
portfolios.go:45:53: Comment should end in a period (godot)
// GetCryptoPortfolios returns crypto portfolio info
                                                    ^
portfolios.go:48: File is not `gofumpt`-ed (gofumpt)
	var portfolioURL = EPCryptoPortfolio + c.CryptoAccount.ID
positions.go:33:2: var-naming: struct field Id should be ID (revive)
	Id                       string        `json:"id"`
	^
positions.go:39:2: var-naming: struct field Id should be ID (revive)
	Id             string `json:"id"`
	^
positions.go:67:76: Comment should end in a period (godot)
// Encode returns the query string associated with the requested parameters
                                                                           ^
quote.go:9:24: Comment should end in a period (godot)
// current stock quotes
                       ^
quote.go:25:80: Comment should end in a period (godot)
// GetQuote returns all the latest stock quotes for the list of stocks provided
                                                                               ^
quote.go:33:57: Comment should end in a period (godot)
// Price returns the proper stock price even after hours
                                                        ^
time-in-force.go:11:41: Comment should end in a period (godot)
// MarshalJSON implements json.Marshaler
                                        ^
time-in-force.go:17:37: Comment should end in a period (godot)
// Well-known values for TimeInForce
                                    ^
times.go:46:11: Comment should end in a period (godot)
// weekday
          ^
times.go:47:16: unused-parameter: parameter 't' seems to be unused, consider removing or renaming it as _ (revive)
func IsWeekDay(t time.Time) bool {
               ^
times.go:101: File is not `gofumpt`-ed (gofumpt)
	return nextWeekdayHourMinuteNY(HrExtendedOpen, 00)
times.go:107: File is not `gofumpt`-ed (gofumpt)
	return nextWeekdayHourMinuteNY(HrRHExtendedOpen, 00)
times.go:112: File is not `gofumpt`-ed (gofumpt)
	return nextWeekdayHourMinuteNY(HrClose, 00)
times.go:119: File is not `gofumpt`-ed (gofumpt)
	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 00)
times.go:126: File is not `gofumpt`-ed (gofumpt)
	return nextWeekdayHourMinuteNY(HrRHExtendedClose, 00)
watchlists.go:16:17: struct-tag: unknown option 'ignore' in JSON tag (revive)
	Client *Client `json:",ignore"`
```
